### PR TITLE
feat(_toBuffer): allows passing bools to `_toBuffer` w/out raising type error

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,9 @@ function _toBuffer(v) {
       else if (typeof v === 'number') {
           v = intToBuffer(v);
       }
+      else if (typeof v === 'boolean') {
+          v = Buffer.from(v ? intToBuffer(1) : intToBuffer(0));
+      }
       else if (v === null || v === undefined) {
           v = Buffer.allocUnsafe(0);
       }


### PR DESCRIPTION
... per title. 

Fixes issue when using for example __[Zmitton's Eth-Object library](https://github.com/zmitton/eth-object)__ which attempts to pass booleans to `_toBuffer` in this library. __[(Here is an example of the latter...)](https://github.com/zmitton/eth-object/blob/c11283243bb0745c52a8827b1b72e86b826aa094/src/receipt.js#L28)__